### PR TITLE
Fix deprecated

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 sperrichon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/Controller/BaseController.php
+++ b/src/Controller/BaseController.php
@@ -2,16 +2,14 @@
 
 namespace SP\RealTimeBundle\Controller;
 
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
 
 class BaseController extends Controller
 {
     /**
-     * @Method("GET")
-     * @Route("/realtime/", name="sp_real_time_endpoint")
+     * @Route("/realtime/", name="sp_real_time_endpoint", methods={"GET"})
      *
      * @return Response
      */

--- a/src/Controller/PresenceController.php
+++ b/src/Controller/PresenceController.php
@@ -4,19 +4,17 @@ namespace SP\RealTimeBundle\Controller;
 
 use Ramsey\Uuid\Exception\InvalidUuidStringException;
 use Ramsey\Uuid\Uuid;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Annotation\Route;
 
 class PresenceController extends Controller
 {
     /**
-     * @Method("POST")
-     * @Route("/realtime/presence/{channel}", name="sp_real_time_presence_subscribe")
+     * @Route("/realtime/presence/{channel}", name="sp_real_time_presence_subscribe", methods={"POST"})
      *
      * @param string $channel
      *
@@ -28,8 +26,7 @@ class PresenceController extends Controller
     }
 
     /**
-     * @Method("DELETE")
-     * @Route("/realtime/presence/{channel}/{uuid}", name="sp_real_time_presence_unsubscribe")
+     * @Route("/realtime/presence/{channel}/{uuid}", name="sp_real_time_presence_unsubscribe", methods={"DELETE"})
      *
      * @param string $channel
      *
@@ -51,8 +48,7 @@ class PresenceController extends Controller
     }
 
     /**
-     * @Method("POST")
-     * @Route("/realtime/presence/{channel}/{uuid}/beacon_unsubscribe", name="sp_real_time_presence_beacon_unsubscribe")
+     * @Route("/realtime/presence/{channel}/{uuid}/beacon_unsubscribe", name="sp_real_time_presence_beacon_unsubscribe", methods={"POST"})
      *
      * @param string $channel
      * @param string $uuid


### PR DESCRIPTION
> User Deprecated: The "Sensio\Bundle\FrameworkExtraBundle\Configuration\Method" annotation is deprecated since version 5.2. Use "Symfony\Component\Routing\Annotation\Route" instead.